### PR TITLE
Add the concept of managers to the SmartGrow system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,22 +5,30 @@ DATABASE_NAME=smartgrow
 DATABASE_SCHEMA=cps/database/schemas/plants.sql
 
 SERVER_MAIN=cps/CentralProcessingServer.java
+SIMULATION_MAIN=endpoint/simulation/SimulatedPlantEndpoint.java
 SERVER_CLASS=cps.CentralProcessingServer
+SIMULATION_CLASS=endpoint.simulation.SimulatedPlantEndpoint
 
 
-all: compile-server
+all: clean compile-server compile-simulation
 
 clean:
 	rm -rf dist
 
 create-database:
-	psql -c "\i ${DATABASE_SCHEMA};"
+	psql -U "smartgrow_client" -c "\i ${DATABASE_SCHEMA};"
 
 destroy-database:
-	psql -c "DROP DATABASE ${DATABASE_NAME};"
+	psql -U "smartgrow_client" -c "DROP DATABASE ${DATABASE_NAME};"
 
 compile-server:
 	javac -proc:none -d "${DIST_PATH}" -cp "${JAVA_LIBRARIES}:." ${SERVER_MAIN}
 
+compile-simulation:
+	javac -proc:none -d "${DIST_PATH}" -cp "${JAVA_LIBRARIES}:." ${SIMULATION_MAIN}
+
 server: compile-server
 	java -cp "${JAVA_LIBRARIES}:${DIST_PATH}:." ${SERVER_CLASS}
+
+simulation: compile-simulation
+	java -cp "${JAVA_LIBRARIES}:${DIST_PATH}:." ${SIMULATION_CLASS}

--- a/cps/CentralProcessingServer.java
+++ b/cps/CentralProcessingServer.java
@@ -7,6 +7,8 @@ import org.apache.logging.log4j.Logger;
 
 import cps.database.DatabaseController;
 import cps.database.exceptions.SmartgrowDatabaseException;
+import cps.management.managers.AndroidUserManager;
+import cps.management.managers.PlantEndpointManager;
 import network.Configuration;
 import network.stem.Stem;
 
@@ -38,6 +40,10 @@ public class CentralProcessingServer {
             logger.fatal("Unable to create database controller: " + ex.getMessage());
             System.exit(1);
         }
+
+        // Attach the leaf managers to the stem.
+        this.stem.addPlantsManager(new PlantEndpointManager(this.controller));
+        this.stem.addAndroidUsersManager(new AndroidUserManager(this.controller));
     }
 
     public static void main(String[] args) {

--- a/cps/database/DatabaseInfo.java
+++ b/cps/database/DatabaseInfo.java
@@ -20,4 +20,7 @@ public class DatabaseInfo {
 
     // This is the environment variable name which will be used to dynamically retrieve the password.
     public static final String DATABASE_PASSWORD = "SMARTGROW_PASSWORD";
+
+    // The table name for the plant sensors data
+    public static final String DATABASE_SENSORS_TABLE = "plant_data";
 }

--- a/cps/database/schemas/plants.sql
+++ b/cps/database/schemas/plants.sql
@@ -10,3 +10,11 @@ CREATE TABLE recommended_properties(
     air_temperature NUMERIC,
     soil_moisture NUMERIC
 );
+
+CREATE TABLE plant_data(
+    plant_id NUMERIC,
+    light_intensity NUMERIC,
+    air_humidity NUMERIC,
+    air_temperature NUMERIC,
+    soil_moisture NUMERIC
+);

--- a/cps/database/wrappers/PlantData.java
+++ b/cps/database/wrappers/PlantData.java
@@ -1,0 +1,50 @@
+package cps.database.wrappers;
+
+import cps.database.DatabaseInfo;
+import cps.database.exceptions.SmartgrowDatabaseException;
+import cps.database.DatabaseController;
+import endpoint.sensors.SupportedSensors;
+import network.core.packets.SensorsData;
+
+/**
+ * PlantData is a DatabaseController wrapper for the plant_data
+ * table. It provides methods for inserting and retrieving
+ * sensors data.
+ * 
+ * @author Ahmed Sakr
+ * @since November 6, 2019
+ */
+public class PlantData {
+
+    // Object representation for manipulating the database.
+    private DatabaseController database;
+
+    /**
+     * Initialize the wrapper for the plant_data table in the database.
+     *
+     * @param database Object reppresentation for manipulating the database.
+     */
+    public PlantData(DatabaseController database) {
+        this.database = database;
+    }
+    
+    /**
+     * Insert the sensors data into the plant_data table.
+     *
+     * @param data The SensorsData packet retrieved from a plant endpoint.
+     * @throws SmartgrowDatabaseException
+     */
+    public void insertSensorsData(SensorsData data) throws SmartgrowDatabaseException {
+        String sql = String.format(
+            "INSERT INTO %s (plant_id, light_intensity, air_humidity, air_temperature, soil_moisture) " +
+            "VALUES (%d, %f, %f, %f ,%f);",
+             DatabaseInfo.DATABASE_SENSORS_TABLE, 1,
+             data.getSensorData(SupportedSensors.LIGHT_INTENSITY),
+             data.getSensorData(SupportedSensors.AIR_HUMIDITY),
+             data.getSensorData(SupportedSensors.AIR_TEMPERATURE),
+             data.getSensorData(SupportedSensors.SOIL_MOISTURE));
+
+        // Update the database with the prepared SQL statement.
+        this.database.update(sql);
+    }
+}

--- a/cps/management/LeafManager.java
+++ b/cps/management/LeafManager.java
@@ -1,0 +1,22 @@
+package cps.management;
+
+import network.core.Packet;
+
+/**
+ * LeafManager provides an interface for classes to implement
+ * for handling a packet received from a leaf.
+ * 
+ * @author Ahmed Sakr
+ * @since November 6, 2019
+ */
+public interface LeafManager {
+
+    /**
+     * Handle a packet received from a leaf.
+     *
+     * @param packet A SmartGrow packet received from the leaf.
+     * @return      true    If handling went as expected
+     *              false   Otherwise
+     */
+    boolean handle(Packet packet);
+}

--- a/cps/management/managers/AndroidUserManager.java
+++ b/cps/management/managers/AndroidUserManager.java
@@ -1,0 +1,35 @@
+package cps.management.managers;
+
+import cps.database.DatabaseController;
+import cps.management.LeafManager;
+import network.core.Packet;
+
+/**
+ * AndroidUserManager provides the behaviour for interacting with
+ * packets received from android users.
+ * 
+ * @author Ahmed Sakr
+ * @since November 6, 2019
+ */
+public class AndroidUserManager implements LeafManager {
+
+    // Object representation for connecting and updating the database.
+    private DatabaseController database;
+
+    /**
+     * Initialize the manager for android users.
+     *
+     * @param database The object representation for connecting to the database.
+     */
+    public AndroidUserManager(DatabaseController database) {
+        this.database = database;
+    }
+
+    /**
+     * The handle instance for android user packets. Unimplemented at the moment.
+     */
+    @Override
+    public boolean handle(Packet packet) {
+        return false;
+    }
+}

--- a/cps/management/managers/PlantEndpointManager.java
+++ b/cps/management/managers/PlantEndpointManager.java
@@ -1,0 +1,61 @@
+package cps.management.managers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import cps.database.DatabaseController;
+import cps.database.exceptions.SmartgrowDatabaseException;
+import cps.database.wrappers.PlantData;
+import cps.management.LeafManager;
+import network.core.Packet;
+import network.core.packets.SensorsData;
+
+/**
+ * PlantEndpointManager defines the behaviour when interacting with
+ * packets received from leaves that identify as plant endpoints.
+ * 
+ * @author Ahmed Sakr
+ * @since November 6, 2019
+ */
+public class PlantEndpointManager implements LeafManager {
+
+    // The logger instance for this class.
+    private static Logger logger = LogManager.getLogger(PlantEndpointManager.class);
+
+    // Object representations for accessing and updating the database
+    private DatabaseController database;
+    private PlantData plantsData;
+
+    /**
+     * Initialize a PlantEndpointManager object with the DatabaseController
+     * object.
+     *
+     * @param database The DatabaseController object providing us with access to the database.
+     */
+    public PlantEndpointManager(DatabaseController database) {
+        this.database = database;
+        this.plantsData = new PlantData(database);
+    }
+
+    /**
+     * The handling implementation for plant endpoints.
+     */
+    @Override
+    public boolean handle(Packet packet) {
+        if (!(packet instanceof SensorsData)) {
+            return false;
+        }
+
+        try {
+
+            // Attempt to append the sensors data to the plant_data table.
+            this.plantsData.insertSensorsData((SensorsData) packet);
+
+        } catch (SmartgrowDatabaseException ex) {
+            logger.fatal("Unable to append data: " + ex.getMessage());
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/network/branch/threads/LeafPruningThread.java
+++ b/network/branch/threads/LeafPruningThread.java
@@ -8,7 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import network.branch.Branch;
-import network.branch.DedicatedLeafServicer;
+import network.branch.threads.DedicatedLeafServicer;
 
 /**
  * LeafPruningThread is spawned when a branch is created to

--- a/network/stem/Stem.java
+++ b/network/stem/Stem.java
@@ -6,6 +6,7 @@ import java.net.SocketException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import cps.management.LeafManager;
 import network.branch.Branch;
 import network.core.NodeLocation;
 import network.core.Packet;
@@ -37,6 +38,24 @@ public class Stem extends Transport {
         this.plants = new Branch("Plants");
         this.users = new Branch("Users");
         this.listenForClients();
+    }
+
+    /**
+     * Installs a manager for the plants in the SmartGrow system.
+     *
+     * @param manager A LeafManager implementing instance.
+     */
+    public void addPlantsManager(LeafManager manager) {
+        this.plants.attachManager(manager);
+    }
+
+    /**
+     * Installs a manager for the android users in the SmartGrow system.
+     *
+     * @param manager A LeafManager implementing instance.
+     */
+    public void addAndroidUsersManager(LeafManager manager) {
+        this.users.attachManager(manager);
     }
 
     /**


### PR DESCRIPTION
* The concept of managers has been integrated into the SmartGrow system. Managers provide the ability to implement different behaviour with dealing with packets for leaves with different identities.
* The plant endpoint manager is implemented. Currently, when a `SensorsData` packet is received from a plant endpoint, its data is appended to the `plant_data` database table.
* The android user manager is not implemented at this moment.